### PR TITLE
[Test] refactored longevity test per libindy changes

### DIFF
--- a/libmysqlstorage/tests/java_libindy_integration_tests/src/test/java/mysql_integration_tests/tests/WalletLongevityTest.java
+++ b/libmysqlstorage/tests/java_libindy_integration_tests/src/test/java/mysql_integration_tests/tests/WalletLongevityTest.java
@@ -238,9 +238,9 @@ public class WalletLongevityTest extends BaseTest {
             logger.debug("finishing ...");
         }
 
-        private void createWallet(String name, int walletID) throws IndyException, ExecutionException, InterruptedException {
+        private void createWallet(String walletName, int walletID) throws IndyException, ExecutionException, InterruptedException {
             logger.trace("Creating wallet with ID'" + walletID + "' of current status '" + walletsStatuses[walletID] + "'");
-            Wallet.createWallet(getDefaultConfig(name), getDefaultCredentials()).get();
+            Wallet.createWallet(getDefaultConfig(walletName), getDefaultCredentials()).get();
             logger.trace("Created wallet with ID'" + walletID + "' of current status '" + walletsStatuses[walletID] + "'");
             walletsStatuses[walletID] = 0;
         }


### PR DESCRIPTION
Signed-off-by: Nemanja Veskovic <nemanja.veskovic@gmail.com>

Actaully changed:
Lines 58 and 60: before class `deleteWallet` call is updated
Line 137: after class `deleteWallet` call is updated
Lines 243 and 249: `create` and `open` wallet calls updated

All other lines are just uncomments 